### PR TITLE
Update terminal_commands.md

### DIFF
--- a/Getting started/terminal_commands.md
+++ b/Getting started/terminal_commands.md
@@ -23,3 +23,4 @@ Use `arrow-up` to access the last command
 In Macs use `cmd + v` to paste text into the terminal
 
 In Windows machines use `shift + insert` to paste text into Git bash
+#You can also use `ctrl + v` to paste on Windows


### PR DESCRIPTION
Saw several times where `shift + insert` was being used rather than `ctrl + v` which is a little easier to use as those are keys that are regularly used rather than the insert key. 